### PR TITLE
🔀🔧 Disable renovate for flutter-plugin-loader package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,12 @@
       ],
       "commitMessagePrefix": "⬇️",
       "commitMessageAction": "Downgrade"
+    },
+    {
+      "matchPackageNames": [
+        "dev.flutter.flutter-plugin-loader"
+      ],
+      "enabled": false
     }
   ],
   "dependencyDashboardTitle": "📌 Dependency Dashboard",


### PR DESCRIPTION
This pull request includes a change to the `.github/renovate.json` file to disable updates for a specific package.

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3R28-R33): Added a configuration to disable updates for the `dev.flutter.flutter-plugin-loader` package.
* This supresses the warning in renovate dashboard